### PR TITLE
Expansion the correct map before testing bits

### DIFF
--- a/BSSolv.xs
+++ b/BSSolv.xs
@@ -2601,7 +2601,7 @@ expand(BSSolv::expander xp, ...)
 		    if ((s = strchr(s + 1, ':')) != 0)
 		      {
 			id = pool_str2id(pool, s + 1, 1);
-			MAPEXP(&xp->ignored, id);
+			MAPEXP(&xp->ignoredx, id);
 			if (MAPTST(&xp->ignoredx, id))
 			  continue;
 			MAPSET(&xp->ignoredx, id);


### PR DESCRIPTION
We hit some quite uncommon crash in our OBS setup where bssolv was
trying to test a bit in a map of size 0. Inspection of the code showed
that while it tried to expand the map to a correct size before the test,
the map it actually expanded wasn't the one it was testing for..
