### PR TITLE
Require all relational operators to be surrounded by spaces.

### DIFF
--- a/BSSolv.xs
+++ b/BSSolv.xs
@@ -165,7 +165,7 @@ dep2id(Pool *pool, char *s)
   while (*s == ' ' || *s == '\t')
     s++;
   n = s;
-  while (*s && *s != ' ' && *s != '\t' && *s != '<' && *s != '=' && *s != '>')
+  while (*s && *s != ' ' && *s != '\t')
     s++;
 #ifdef REL_MULTIARCH
   if (s - n > 4 && s[-4] == ':' && !strncmp(s - 4, ":any", 4))


### PR DESCRIPTION
Some capabilities provided or required by RPM packages can have equal sign inside the name. For example, various font packages in Fedora provide capabilities with names looking like `font(:lang=XX)` where `XX` is language code.

Unfortunately, dependency parser in `BSSolv` module (`dep2id()` function in `BSSolv.xs` file) interprets this equal sign as a relational operator resulting in wrong versioned capability `font(:lang` with version equal to something looking like `XX)` (where `XX` is language code) when importing repositories using `$pool->repofromdata()` or `$repo->updatedoddata()` methods.

This change provides a workaround for this problem by ignoring relational operators not separated by space from capability name and treating them as part of capability name.
