### PR TITLE
Align Debian and Arch support to libsolv

### DIFF
--- a/BSSolv.xs
+++ b/BSSolv.xs
@@ -26,8 +26,10 @@
 #include "repo_solv.h"
 #include "repo_write.h"
 #include "repo_rpmdb.h"
+#if defined(LIBSOLVEXT_FEATURE_DEBIAN)
 #include "repo_deb.h"
-#if 1
+#endif
+#if defined(LIBSOLVEXT_FEATURE_ARCHREPO)
 #include "repo_arch.h"
 #endif
 #if defined(LIBSOLV_FEATURE_COMPLEX_DEPS)
@@ -2867,8 +2869,10 @@ repodata_addbin(Repodata *data, char *prefix, char *s, int sl, char *sid)
   path = solv_dupjoin(prefix, "/", s);
   if (sl >= 4 && !strcmp(s + sl - 4, ".rpm"))
     p = repo_add_rpm(data->repo, (const char *)path, REPO_REUSE_REPODATA|REPO_NO_INTERNALIZE|REPO_NO_LOCATION|RPM_ADD_WITH_PKGID|RPM_ADD_NO_FILELIST|RPM_ADD_NO_RPMLIBREQS);
+#if defined(LIBSOLVEXT_FEATURE_DEBIAN)
   else if (sl >= 4 && !strcmp(s + sl - 4, ".deb"))
     p = repo_add_deb(data->repo, (const char *)path, REPO_REUSE_REPODATA|REPO_NO_INTERNALIZE|REPO_NO_LOCATION|DEBS_ADD_WITH_PKGID);
+#endif
   else if (sl >= 10 && !strcmp(s + sl - 10, ".obsbinlnk"))
     {
       p = repo_add_obsbinlnk(data->repo, (const char *)path, REPO_REUSE_REPODATA|REPO_NO_INTERNALIZE|REPO_NO_LOCATION);
@@ -2878,7 +2882,7 @@ repodata_addbin(Repodata *data, char *prefix, char *s, int sl, char *sid)
         repodata_set_str(data, p, buildservice_id, sid);
       return p;
     }
-#ifdef ARCH_ADD_WITH_PKGID
+#if defined(LIBSOLVEXT_FEATURE_ARCHREPO) && defined(ARCH_ADD_WITH_PKGID)
   else if (sl >= 11 && (!strcmp(s + sl - 11, ".pkg.tar.gz") || !strcmp(s + sl - 11, ".pkg.tar.xz")))
     p = repo_add_arch_pkg(data->repo, (const char *)path, REPO_REUSE_REPODATA|REPO_NO_INTERNALIZE|REPO_NO_LOCATION|ARCH_ADD_WITH_PKGID);
 #endif


### PR DESCRIPTION
This patch is used in Fedora to be able to support building `perl-BSSolv` against `libsolv` in CentOS/RHEL 7, which lacks support for Debian and Arch repositories and packages at this time.