### PR TITLE
Add option to not ignore file requires

### DIFF
--- a/t/filerequires.t
+++ b/t/filerequires.t
@@ -1,0 +1,72 @@
+#!/usr/bin/perl -w
+
+use strict;
+use Test::More tests => 12;
+
+require 't/testlib.pm';
+
+my $repo = <<'EOR';
+P: a = 1-1
+R: b
+P: b = 1-1
+R: /file
+s: e
+P: c = 1-1
+P: d = 1-1
+r: b
+P: e = 1-1
+EOR
+
+my $config = setuptest($repo);
+my @r;
+
+@r = expand($config, 'a');
+is_deeply(\@r, [1, 'a', 'b'], 'ignored file requires');
+
+$config = setuptest($repo, "FileProvides: /file c");
+@r = expand($config, 'a');
+is_deeply(\@r, [1, 'a', 'b', 'c'], 'honoured file requires');
+
+$config = setuptest($repo, "ExpandFlags: keepfilerequires");
+@r = expand($config, 'a');
+is_deeply(\@r, [undef, 'nothing provides /file needed by b'], 'missing file provides');
+
+$config = setuptest($repo, "ExpandFlags: keepfilerequires\nFileProvides: /file c");
+@r = expand($config, 'a');
+is_deeply(\@r, [1, 'a', 'b', 'c'], 'honoured file requires');
+
+$config = setuptest($repo, "ExpandFlags: dorecommends");
+@r = expand($config, 'd');
+is_deeply(\@r, [1, 'b', 'd'], 'ignored file requires');
+
+$config = setuptest($repo, "ExpandFlags: dorecommends\nFileProvides: /file c");
+@r = expand($config, 'd');
+is_deeply(\@r, [1, 'b', 'c', 'd'], 'honoured file requires');
+
+$config = setuptest($repo, "ExpandFlags: dorecommends keepfilerequires");
+@r = expand($config, 'd');
+# This should rather just ignore b
+# is_deeply(\@r, [1, 'd'], 'missing file provides');
+is_deeply(\@r, [undef, 'nothing provides /file needed by b'], 'missing file provides');
+
+$config = setuptest($repo, "ExpandFlags: dorecommends keepfilerequires\nFileProvides: /file c");
+@r = expand($config, 'd');
+is_deeply(\@r, [1, 'b', 'c', 'd'], 'honoured file requires');
+
+$config = setuptest($repo, "ExpandFlags: dosupplements");
+@r = expand($config, 'e');
+is_deeply(\@r, [1, 'b', 'e'], 'ignored file requires');
+
+$config = setuptest($repo, "ExpandFlags: dosupplements\nFileProvides: /file c");
+@r = expand($config, 'e');
+is_deeply(\@r, [1, 'b', 'c', 'e'], 'honoured file requires');
+
+$config = setuptest($repo, "ExpandFlags: dosupplements keepfilerequires");
+@r = expand($config, 'e');
+# This should rather just ignore b
+# is_deeply(\@r, [1, 'e'], 'missing file provides');
+is_deeply(\@r, [undef, 'nothing provides /file needed by b'], 'missing file provides');
+
+$config = setuptest($repo, "ExpandFlags: dosupplements keepfilerequires\nFileProvides: /file c");
+@r = expand($config, 'e');
+is_deeply(\@r, [1, 'b', 'c', 'e'], 'honoured file requires');

--- a/t/testlib.pm
+++ b/t/testlib.pm
@@ -24,6 +24,9 @@ sub read_config {
       push @{$config->{substr($l0, 0, -1)}}, @l;
     } elsif ($l0 eq 'binarytype:') {
       $config->{'binarytype'} = $l[0];
+    } elsif ($l0 eq 'fileprovides:') {
+      my $f = shift @l;
+      push @{$config->{'fileprovides'}->{$f}}, @l;
     } elsif ($l0 !~ /^[#%]/) {
       die("unknown keyword in config: $l0\n");
     }


### PR DESCRIPTION
Currently it honours file requires only if there's a matching FileProvides
defined, but this leads to silently breaking dependencies. Add a flag to allow
changing the behaviour.

I thought that for recommends and supplements it did some backtracking if a dependency can't be fulfilled, but apparently that's not the case? That unfortunately makes it less useful for those.

I used this in a local OBS instance and it appears to work: With this flag set, builds turn unresolvable instead of breaking deps.

Unfortunately it does that also for dependencies which are fulfilled already, e.g. if something requires both `coreutils` and `/bin/mv`, it'll complain about `/bin/mv` anyway because the information isn't available yet. Apparently @mls is working on that with https://github.com/openSUSE/obs-build/commit/10a000781e1b5e2f7cd262ae9e6c9900e33de545#diff-89d1f99543b08cecf30aee69277f066ea8ef020a4f412d69553b5958c01b3820 though?