### PR TITLE
Add helpful message if a file provides is missing

### DIFF
--- a/BSSolv.xs
+++ b/BSSolv.xs
@@ -8125,10 +8125,12 @@ expand(BSSolv::expander xp, ...)
 		      {
 			id = out.elements[i + 1];
 			who = out.elements[i + 2];
+			const char *idstr = pool_dep2str(pool, id);
+			const char *fileprovmsg = idstr[0] == '/' ? " (missing FileProvides?)" : "";
 			if (who)
-		          sv = newSVpvf("nothing provides %s needed by %s", pool_dep2str(pool, id), solvid2name(pool, who));
+		          sv = newSVpvf("nothing provides %s needed by %s%s", idstr, solvid2name(pool, who), fileprovmsg);
 			else
-		          sv = newSVpvf("nothing provides %s", pool_dep2str(pool, id));
+		          sv = newSVpvf("nothing provides %s%s", idstr, fileprovmsg);
 			i += 3;
 		      }
 		    else if (type == ERROR_ALLCONFLICT)

--- a/t/filerequires.t
+++ b/t/filerequires.t
@@ -29,7 +29,7 @@ is_deeply(\@r, [1, 'a', 'b', 'c'], 'honoured file requires');
 
 $config = setuptest($repo, "ExpandFlags: keepfilerequires");
 @r = expand($config, 'a');
-is_deeply(\@r, [undef, 'nothing provides /file needed by b'], 'missing file provides');
+is_deeply(\@r, [undef, 'nothing provides /file needed by b (missing FileProvides?)'], 'missing file provides');
 
 $config = setuptest($repo, "ExpandFlags: keepfilerequires\nFileProvides: /file c");
 @r = expand($config, 'a');
@@ -47,7 +47,7 @@ $config = setuptest($repo, "ExpandFlags: dorecommends keepfilerequires");
 @r = expand($config, 'd');
 # This should rather just ignore b
 # is_deeply(\@r, [1, 'd'], 'missing file provides');
-is_deeply(\@r, [undef, 'nothing provides /file needed by b'], 'missing file provides');
+is_deeply(\@r, [undef, 'nothing provides /file needed by b (missing FileProvides?)'], 'missing file provides');
 
 $config = setuptest($repo, "ExpandFlags: dorecommends keepfilerequires\nFileProvides: /file c");
 @r = expand($config, 'd');
@@ -65,7 +65,7 @@ $config = setuptest($repo, "ExpandFlags: dosupplements keepfilerequires");
 @r = expand($config, 'e');
 # This should rather just ignore b
 # is_deeply(\@r, [1, 'e'], 'missing file provides');
-is_deeply(\@r, [undef, 'nothing provides /file needed by b'], 'missing file provides');
+is_deeply(\@r, [undef, 'nothing provides /file needed by b (missing FileProvides?)'], 'missing file provides');
 
 $config = setuptest($repo, "ExpandFlags: dosupplements keepfilerequires\nFileProvides: /file c");
 @r = expand($config, 'e');


### PR DESCRIPTION
Some might not know that specifying FileProvides in the config is necessary.

Related to #14, but independent (except for strings in the test suite).