### PR TITLE
Accept "0" as an epoch

### DIFF
--- a/BSSolv.xs
+++ b/BSSolv.xs
@@ -207,8 +207,6 @@ makeevr(Pool *pool, char *e, char *v, char *r)
 
   if (!v)
     return 0;
-  if (e && !strcmp(e, "0"))
-    e = 0;
   if (e)
     s = pool_tmpjoin(pool, e, ":", v);
   else


### PR DESCRIPTION
In Debian an zero epoch is actually valid; e.g. woff-tools actually has a zero epoch (0:2009.10.04-2).